### PR TITLE
Rearranged code for `fixed`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ While in version ``0``, minor and patch upgrades converge in the ``patch`` numbe
 Changelog
 =========
 
+* Add option to build backbone conformers with fixed bond angle and
+  distances. (#217)
+
 v0.6.7 (2022-05-31)
 ------------------------------------------------------------
 

--- a/src/idpconfgen/cli_build.py
+++ b/src/idpconfgen/cli_build.py
@@ -28,6 +28,7 @@ from idpconfgen.components.bgeo_strategies import (
     bgeo_strategies,
     bgeo_strategies_default,
     )
+from idpconfgen.components.bgeo_strategies.fixed import get_cycle_bend_angles
 from idpconfgen.components.energy_threshold_type import add_et_type_arg
 from idpconfgen.components.residue_tolerance import add_res_tolerance_groups
 from idpconfgen.components.sidechain_packing import (
@@ -59,7 +60,6 @@ from idpconfgen.libs import libcli
 from idpconfgen.libs.libbuild import (
     build_regex_substitutions,
     create_sidechains_masks_per_residue,
-    get_cycle_bend_angles,
     get_cycle_bond_type,
     get_cycle_distances_backbone,
     init_conflabels,
@@ -165,14 +165,14 @@ def are_globals(bgeo_strategy):
             BGEO_res,
             ))
     elif bgeo_strategy == bgeo_fixed_name:
-        return all ((
+        return all((
             ALL_ATOM_LABELS,
             ALL_ATOM_MASKS,
             ALL_ATOM_EFUNC,
             TEMPLATE_LABELS,
             TEMPLATE_MASKS,
             TEMPLATE_EFUNC,
-        ))
+            ))
     elif bgeo_strategy == bgeo_int2cart_name:
         return all((
             ALL_ATOM_LABELS,
@@ -1059,7 +1059,7 @@ def conformer_generator(
         # prepares cycles for building process
         bond_lens = get_cycle_distances_backbone()
         bond_type = get_cycle_bond_type()
-        
+
         if bgeo_strategy == bgeo_fixed_name:
             bend_angles = get_cycle_bend_angles()
 
@@ -1178,7 +1178,7 @@ def conformer_generator(
                         elif bgeo_strategy == bgeo_fixed_name:
                             _bend_angle = next(bend_angles)[curr_res]
                             _bond_lens = next(bond_lens)[curr_res]
-                            
+
                         bb_real[bbi, :] = MAKE_COORD_Q_LOCAL(
                             bb[bbi - 1, :],
                             bb[bbi, :],
@@ -1197,7 +1197,7 @@ def conformer_generator(
                                 co_bend = RC(BGEO_trimer['Ca_C_O'][curr_res][tpair])
                             except KeyError:
                                 co_bend = RC(BGEO_res['Ca_C_O'][curr_res])
-                                
+
                     elif bgeo_strategy == bgeo_fixed_name:
                         co_bend = build_bend_CA_C_O
 

--- a/src/idpconfgen/components/bgeo_strategies/__init__.py
+++ b/src/idpconfgen/components/bgeo_strategies/__init__.py
@@ -6,14 +6,14 @@ from idpconfgen.components.bgeo_strategies.int2cart.bgeo_int2cart import (
     )
 from idpconfgen.components.bgeo_strategies.int2cart.bgeo_int2cart import \
     name as bgeo_int2cart_name
+from idpconfgen.components.bgeo_strategies.fixed import \
+    name as bgeo_fixed_name
 from idpconfgen.components.bgeo_strategies.sampling import \
     name as bgeo_sampling_name
 
 
 bgeo_strategies_default = bgeo_sampling_name
 """The default bond geometry sampling strategy."""
-
-bgeo_fixed_name = "fixed"
 
 bgeo_strategies = (
     bgeo_fixed_name,

--- a/src/idpconfgen/components/bgeo_strategies/fixed/__init__.py
+++ b/src/idpconfgen/components/bgeo_strategies/fixed/__init__.py
@@ -1,0 +1,22 @@
+"""Module to build backbone geometry angles with fixed values."""
+from itertools import cycle
+
+from idpconfgen.core.build_definitions import (
+    build_bend_angles_CA_C_Np1,
+    build_bend_angles_Cm1_N_CA,
+    build_bend_angles_N_CA_C,
+    )
+
+
+name = "fixed"
+
+
+def get_cycle_bend_angles():
+    """
+    Return an infinite iterator of the bend angles.
+    """
+    return cycle((
+        build_bend_angles_Cm1_N_CA,  # used for OMEGA
+        build_bend_angles_N_CA_C,  # used for PHI
+        build_bend_angles_CA_C_Np1,  # used for PSI
+        ))

--- a/src/idpconfgen/core/definitions.py
+++ b/src/idpconfgen/core/definitions.py
@@ -179,37 +179,35 @@ blocked_ids = [
 residue_elements = {'C', 'O', 'N', 'H', 'S', 'Se', 'D'}
 minimal_bb_atoms = ['N', 'CA', 'C']  # ordered!
 
-'''
-"""
-Builder Definitions For Fixed Bond Geometries
----------------------------------------------
-Average values of the backbone angles calculated from Dunbrack PISCES
-cull_d200611/200611/cullpdb_pc90_res1.6_R0.25_d200611_chains8807
-
-Float values are represented as ratio of integers
-https://docs.python.org/3/tutorial/floatingpoint.html
-"""
-average_N_CA_C = 8731046790257777 / 4503599627370496  # +- 0.04375239960584633
-average_CA_C_Np1 = 4587708133805365 / 2251799813685248  # +- 0.022904896537130497
-average_Np1_C_O = 4733796466948169 / 2251799813685248  # +- 0.019050491268134375
-average_CA_C_O = 4825315589323725 / 2251799813685248  # +- 0.017982788310237034
-average_Cm1_N_CA = 2385749441983237 / 1125899906842624  # +- 0.029039312259214314
-bend_CA_C_OXT = 2 * pi / 3
-
-# pi corrected angles needed for the building algorithm
-build_bend_N_CA_C = (pi - average_N_CA_C) / 2
-build_bend_CA_C_Np1 = (pi - average_CA_C_Np1) / 2
-build_bend_CA_C_O = average_CA_C_O / 2  # this angle does not require `pi -`
-build_bend_Cm1_N_CA = (pi - average_Cm1_N_CA) / 2
-build_bend_CA_C_OXT = (pi - bend_CA_C_OXT) / 2
-
-distance_N_CA = 6576479998126497 / 4503599627370496  # 1.46027 +- 0.013036
-distance_CA_C = 6861872558247717 / 4503599627370496  # 1.52364 +- 0.012599
-distance_C_Np1 = 2996436734567847 / 2251799813685248  # 1.33068 +- 0.009621
-distance_C_O = 5556993099130213 / 4503599627370496  # 1.234 +- 0.0121
-distance_C_OXT = 1.27
-
-distance_N_CA_std = 0.013036529567238726
-distance_CA_C_std = 0.012599655969373144
-distance_C_Np1_std = 0.009621596711934686
-'''
+# """
+# Builder Definitions For Fixed Bond Geometries
+# ---------------------------------------------
+# Average values of the backbone angles calculated from Dunbrack PISCES
+# cull_d200611/200611/cullpdb_pc90_res1.6_R0.25_d200611_chains8807
+#
+# Float values are represented as ratio of integers
+# https://docs.python.org/3/tutorial/floatingpoint.html
+# """
+# average_N_CA_C = 8731046790257777 / 4503599627370496  # +- 0.04375239960584633
+# average_CA_C_Np1 = 4587708133805365 / 2251799813685248  # +- 0.022904896537130497
+# average_Np1_C_O = 4733796466948169 / 2251799813685248  # +- 0.019050491268134375
+# average_CA_C_O = 4825315589323725 / 2251799813685248  # +- 0.017982788310237034
+# average_Cm1_N_CA = 2385749441983237 / 1125899906842624  # +- 0.029039312259214314
+# bend_CA_C_OXT = 2 * pi / 3
+#
+# # pi corrected angles needed for the building algorithm
+# build_bend_N_CA_C = (pi - average_N_CA_C) / 2
+# build_bend_CA_C_Np1 = (pi - average_CA_C_Np1) / 2
+# build_bend_CA_C_O = average_CA_C_O / 2  # this angle does not require `pi -`
+# build_bend_Cm1_N_CA = (pi - average_Cm1_N_CA) / 2
+# build_bend_CA_C_OXT = (pi - bend_CA_C_OXT) / 2
+#
+# distance_N_CA = 6576479998126497 / 4503599627370496  # 1.46027 +- 0.013036
+# distance_CA_C = 6861872558247717 / 4503599627370496  # 1.52364 +- 0.012599
+# distance_C_Np1 = 2996436734567847 / 2251799813685248  # 1.33068 +- 0.009621
+# distance_C_O = 5556993099130213 / 4503599627370496  # 1.234 +- 0.0121
+# distance_C_OXT = 1.27
+#
+# distance_N_CA_std = 0.013036529567238726
+# distance_CA_C_std = 0.012599655969373144
+# distance_C_Np1_std = 0.009621596711934686

--- a/src/idpconfgen/libs/libbuild.py
+++ b/src/idpconfgen/libs/libbuild.py
@@ -16,9 +16,6 @@ from idpconfgen.core.build_definitions import (
     distances_C_Np1,
     distances_CA_C,
     distances_N_CA,
-    build_bend_angles_CA_C_Np1,
-    build_bend_angles_Cm1_N_CA,
-    build_bend_angles_N_CA_C,
     )
 from idpconfgen.core.definitions import bgeo_CaCNp1, bgeo_Cm1NCa, bgeo_NCaC
 from idpconfgen.libs.libcalc import (
@@ -300,7 +297,7 @@ def create_conformer_labels(
         shape (N,) where N is the number of atoms.
         The three arrays have the same length.
     """
-    input_seq_3_letters = transfunc(input_seq) # note HIS treated as HIP
+    input_seq_3_letters = transfunc(input_seq)  # note HIS treated as HIP
 
     # change "H" to "p" as idpconfgen builds histidines as HIP,
     # see `translate_seq_to_3l`
@@ -465,18 +462,6 @@ def get_cycle_distances_backbone():
         ))
 
 
-# re-activated for `fixed` bgeo strategy
-def get_cycle_bend_angles():
-    """
-    Return an infinite iterator of the bend angles.
-    """
-    return cycle((
-        build_bend_angles_Cm1_N_CA,  # used for OMEGA
-        build_bend_angles_N_CA_C,  # used for PHI
-        build_bend_angles_CA_C_Np1,  # used for PSI
-        ))
-
-
 def get_cycle_bond_type():
     """
     Return an infinite interator of the bond types.
@@ -570,8 +555,8 @@ def prepare_slice_dict(
     dict
         A dict with the given mapping:
 
-            1) First key-level of the dict is the length of the fragments, hence,
-            integers.
+            1) First key-level of the dict is the length of the fragments,
+            hence, integers.
 
             2) The second key level are the residue fragments found in the
             `primary`. A fragment in input_seq but not in `primary` is removed


### PR DESCRIPTION
I was looking at your proposal https://github.com/julie-forman-kay-lab/IDPConformerGenerator/pull/217 and it's nice.
Just moved some code around. Even if in the case of `fixed` was only a variable name, you still need to create a folder inside `bgeo_strategies` to keep the consistency of the structure.
If you accept this PR then the other can be merged as well.